### PR TITLE
feat: per-user recommendation engine

### DIFF
--- a/src/Jellyfin.Plugin.MediaBar/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Configuration/PluginConfiguration.cs
@@ -13,11 +13,24 @@ namespace Jellyfin.Plugin.MediaBar.Configuration
         public MediaBarState Enabled { get; set; } = MediaBarState.Enabled;
 
         public string VersionString { get; set; } = "main";
-        
+
         public bool UseAvatarsFile { get; set; } = true;
 
         public string AvatarsPlaylist { get; set; } = string.Empty;
-        
+
+        // Recommendation engine settings
+        public bool RecommendationsEnabled { get; set; } = false;
+
+        public int RecommendationTopN { get; set; } = 15;
+
+        public double RecommendationRatingWeight { get; set; } = 0.5;
+
+        public double RecommendationGenreWeight { get; set; } = 0.3;
+
+        public double RecommendationRecencyWeight { get; set; } = 0.2;
+
+        public int RecommendationRecencyDays { get; set; } = 90;
+
         public WebConfig WebConfig { get; set; } = new WebConfig();
     }
 

--- a/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
@@ -1,13 +1,17 @@
-﻿using System.Reflection;
+﻿using System.Globalization;
+using System.Reflection;
+using System.Security.Claims;
 using System.Text.RegularExpressions;
 using Jellyfin.Extensions;
 using Jellyfin.Plugin.MediaBar.Attributes;
 using Jellyfin.Plugin.MediaBar.Configuration;
 using Jellyfin.Plugin.MediaBar.Model;
+using Jellyfin.Plugin.MediaBar.ScheduledTasks;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Playlists;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Jellyfin.Plugin.MediaBar.Helpers
@@ -28,7 +32,27 @@ namespace Jellyfin.Plugin.MediaBar.Helpers
             {
                 return payload.Contents;
             }
-            
+
+            // If recommendations are enabled, try to serve the per-user recommendation playlist
+            if (MediaBarPlugin.Instance.Configuration.RecommendationsEnabled)
+            {
+                Guid? requestingUserId = GetRequestingUserId();
+                if (requestingUserId.HasValue)
+                {
+                    string recoName = UpdateRecommendationsTask.PlaylistPrefix
+                        + requestingUserId.Value.ToString("N", CultureInfo.InvariantCulture);
+
+                    Playlist? recoPlaylist = playlistManager.GetPlaylists(requestingUserId.Value)
+                        .FirstOrDefault(x => x.Name == recoName);
+
+                    if (recoPlaylist is not null)
+                    {
+                        return BuildPlaylistResponse(recoPlaylist, requestingUserId.Value, userManager, shuffle: false);
+                    }
+                }
+            }
+
+            // Fall back to the globally configured playlist (existing behaviour)
             IEnumerable<Guid> allUserIds = userManager.UsersIds;
 
             Playlist? playlist = null;
@@ -51,15 +75,19 @@ namespace Jellyfin.Plugin.MediaBar.Helpers
                 return payload.Contents;
             }
 
+            return BuildPlaylistResponse(playlist, userIdToUse.Value, userManager, shuffle: true);
+        }
+
+        private static string BuildPlaylistResponse(Playlist playlist, Guid userId, IUserManager userManager, bool shuffle)
+        {
             IEnumerable<Tuple<LinkedChild, BaseItem>> itemsRaw = playlist.GetManageableItems()
-                .Where(i => i.Item2.IsVisible(userManager.GetUserById(userIdToUse.Value)));
+                .Where(i => i.Item2.IsVisible(userManager.GetUserById(userId)));
 
             StringWriter stringWriter = new StringWriter();
+            stringWriter.WriteLine(playlist.Name);
 
-            stringWriter.WriteLine(MediaBarPlugin.Instance.Configuration.AvatarsPlaylist);
-                
             List<Guid> idsWritten = new List<Guid>();
-                
+
             foreach (Tuple<LinkedChild, BaseItem> item in itemsRaw)
             {
                 BaseItem itemToUse = item.Item2;
@@ -74,15 +102,43 @@ namespace Jellyfin.Plugin.MediaBar.Helpers
                 }
             }
 
-            idsWritten.Shuffle();
+            if (shuffle)
+            {
+                idsWritten.Shuffle();
+            }
 
             foreach (Guid id in idsWritten)
             {
                 // For some reason the JF api doesn't treat GUIDs correctly
                 stringWriter.WriteLine(id.ToString().Replace("-", ""));
             }
-            
+
             return stringWriter.ToString();
+        }
+
+        private static Guid? GetRequestingUserId()
+        {
+            try
+            {
+                IHttpContextAccessor httpContextAccessor =
+                    MediaBarPlugin.Instance.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
+
+                string? userIdString = httpContextAccessor.HttpContext?.User
+                    ?.FindFirst("Jellyfin-userId")?.Value
+                    ?? httpContextAccessor.HttpContext?.User
+                    ?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+                if (Guid.TryParse(userIdString, out Guid userId))
+                {
+                    return userId;
+                }
+            }
+            catch
+            {
+                // IHttpContextAccessor not available — not critical, fall through to global playlist
+            }
+
+            return null;
         }
         
         public static string IndexHtml(PatchRequestPayload payload)

--- a/src/Jellyfin.Plugin.MediaBar/PluginServiceRegistrator.cs
+++ b/src/Jellyfin.Plugin.MediaBar/PluginServiceRegistrator.cs
@@ -1,6 +1,8 @@
-﻿using Jellyfin.Plugin.MediaBar.Services;
+﻿using Jellyfin.Plugin.MediaBar.ScheduledTasks;
+using Jellyfin.Plugin.MediaBar.Services;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
+using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Jellyfin.Plugin.MediaBar
@@ -9,6 +11,8 @@ namespace Jellyfin.Plugin.MediaBar
     {
         public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
         {
+            serviceCollection.AddHttpContextAccessor();
+            serviceCollection.AddSingleton<IScheduledTask, UpdateRecommendationsTask>();
         }
     }
 }

--- a/src/Jellyfin.Plugin.MediaBar/ScheduledTasks/UpdateRecommendationsTask.cs
+++ b/src/Jellyfin.Plugin.MediaBar/ScheduledTasks/UpdateRecommendationsTask.cs
@@ -1,0 +1,192 @@
+using System.Globalization;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.MediaBar.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Playlists;
+using MediaBrowser.Model.Querying;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.MediaBar.ScheduledTasks
+{
+    public class UpdateRecommendationsTask : IScheduledTask
+    {
+        // Internal playlist name prefix — one playlist per user, not meant to be manually configured
+        internal const string PlaylistPrefix = "_mbr_";
+
+        private readonly ILibraryManager _libraryManager;
+        private readonly IUserManager _userManager;
+        private readonly IUserDataManager _userDataManager;
+        private readonly IPlaylistManager _playlistManager;
+        private readonly ILogger<UpdateRecommendationsTask> _logger;
+
+        public UpdateRecommendationsTask(
+            ILibraryManager libraryManager,
+            IUserManager userManager,
+            IUserDataManager userDataManager,
+            IPlaylistManager playlistManager,
+            ILogger<UpdateRecommendationsTask> logger)
+        {
+            _libraryManager = libraryManager;
+            _userManager = userManager;
+            _userDataManager = userDataManager;
+            _playlistManager = playlistManager;
+            _logger = logger;
+        }
+
+        public string Name => "Update Media Bar Recommendations";
+        public string Key => "MediaBar.UpdateRecommendations";
+        public string Description => "Generates per-user personalized movie recommendations and updates the Media Bar featured playlist for each user.";
+        public string Category => "Media Bar";
+
+        public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+        {
+            var config = MediaBarPlugin.Instance.Configuration;
+
+            if (!config.RecommendationsEnabled)
+            {
+                _logger.LogInformation("[MediaBar] Recommendations disabled, skipping.");
+                return;
+            }
+
+            var allUsers = _userManager.Users.ToList();
+            if (allUsers.Count == 0)
+            {
+                return;
+            }
+
+            double step = 100.0 / allUsers.Count;
+
+            for (int i = 0; i < allUsers.Count; i++)
+            {
+                var user = allUsers[i];
+                cancellationToken.ThrowIfCancellationRequested();
+
+                _logger.LogInformation("[MediaBar] Generating recommendations for user '{User}'.", user.Username);
+
+                try
+                {
+                    await UpdateForUser(user.Id, config).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "[MediaBar] Failed to update recommendations for user '{User}'.", user.Username);
+                }
+
+                progress.Report((i + 1) * step);
+            }
+        }
+
+        private async Task UpdateForUser(Guid userId, PluginConfiguration config)
+        {
+            var user = _userManager.GetUserById(userId);
+            if (user is null)
+            {
+                return;
+            }
+
+            // All movies visible to this user
+            var allMovies = _libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = [BaseItemKind.Movie],
+                IsVirtualItem = false,
+                Recursive = true
+            });
+
+            var watched = allMovies
+                .Where(m => _userDataManager.GetUserData(user, m).Played)
+                .ToList();
+
+            var unwatched = allMovies
+                .Where(m => !_userDataManager.GetUserData(user, m).Played)
+                .ToList();
+
+            // Genre frequency map from watch history
+            var genreFreq = watched
+                .SelectMany(m => m.Genres ?? [])
+                .GroupBy(g => g, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.OrdinalIgnoreCase);
+
+            var maxFreq = genreFreq.Values.DefaultIfEmpty(1).Max();
+
+            var now = DateTime.UtcNow;
+            var topIds = unwatched
+                .Select(movie =>
+                {
+                    double score = 0;
+
+                    if (movie.CommunityRating.HasValue)
+                        score += (movie.CommunityRating.Value / 10.0) * config.RecommendationRatingWeight;
+
+                    if (movie.Genres is { Length: > 0 })
+                    {
+                        var genreScore = movie.Genres
+                            .Where(g => genreFreq.ContainsKey(g))
+                            .Sum(g => genreFreq[g] / (double)maxFreq);
+                        score += Math.Min(genreScore, 1.0) * config.RecommendationGenreWeight;
+                    }
+
+                    var age = (now - movie.DateCreated).TotalDays;
+                    if (age is >= 0 and <= 365)
+                    {
+                        var window = (double)config.RecommendationRecencyDays;
+                        if (age <= window)
+                            score += (1.0 - age / window) * config.RecommendationRecencyWeight;
+                    }
+
+                    return (Id: movie.Id, Score: score);
+                })
+                .OrderByDescending(x => x.Score)
+                .Take(config.RecommendationTopN)
+                .Select(x => x.Id)
+                .ToArray();
+
+            // Internal playlist name for this user
+            string playlistName = PlaylistPrefix + userId.ToString("N", CultureInfo.InvariantCulture);
+
+            var existing = _libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = [BaseItemKind.Playlist],
+                Name = playlistName,
+                Recursive = true
+            }).FirstOrDefault() as Playlist;
+
+            if (existing is not null)
+            {
+                var entryIds = existing.LinkedChildren
+                    .Where(c => c.ItemId.HasValue)
+                    .Select(c => c.ItemId!.Value.ToString("N", CultureInfo.InvariantCulture))
+                    .ToList();
+
+                if (entryIds.Count > 0)
+                    await _playlistManager.RemoveItemFromPlaylistAsync(existing.Id.ToString(), entryIds).ConfigureAwait(false);
+
+                await _playlistManager.AddItemToPlaylistAsync(existing.Id, topIds, userId).ConfigureAwait(false);
+            }
+            else
+            {
+                await _playlistManager.CreatePlaylist(new PlaylistCreationRequest
+                {
+                    Name = playlistName,
+                    ItemIdList = topIds,
+                    UserId = userId,
+                    MediaType = MediaType.Video
+                }).ConfigureAwait(false);
+            }
+
+            _logger.LogInformation("[MediaBar] Playlist updated for user '{User}' with {Count} recommendations.", user.Username, topIds.Length);
+        }
+
+        public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() =>
+        [
+            new TaskTriggerInfo
+            {
+                Type = TaskTriggerInfoType.DailyTrigger,
+                TimeOfDayTicks = TimeSpan.FromHours(3).Ticks
+            }
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a **daily scheduled task** that scores each user's unwatched movies using three weighted factors: community rating, genre affinity (from watch history), and recency bonus
- Generates one internal playlist per user (`_mbr_{userId}`) containing their Top N recommendations
- Modifies `TransformationPatches.AvatarsList()` to detect the requesting user via `IHttpContextAccessor` and serve their personal playlist — falling back gracefully to the existing global playlist behaviour when recommendations are disabled or unavailable
- The feature is **fully opt-in**: a `RecommendationsEnabled` toggle must be set to `true` in plugin settings before anything changes

## New settings

| Setting | Default | Description |
|---|---|---|
| `RecommendationsEnabled` | `false` | Enable/disable the recommendation engine |
| `RecommendationTopN` | `15` | Number of movies per user playlist |
| `RecommendationRatingWeight` | `0.5` | Weight for IMDB/TMDB community rating |
| `RecommendationGenreWeight` | `0.3` | Weight for genre affinity from watch history |
| `RecommendationRecencyWeight` | `0.2` | Weight for recently added movies |
| `RecommendationRecencyDays` | `90` | Window in days for the recency bonus |

## Backwards compatibility

All new settings default to the existing behaviour (`RecommendationsEnabled = false`). Existing installations are completely unaffected until the feature is explicitly enabled.

## Test plan

- [ ] Install plugin, verify existing playlist behaviour unchanged with `RecommendationsEnabled = false`
- [ ] Enable recommendations, run task manually, verify per-user playlists created
- [ ] Log in as different users, verify each sees their own recommendations in the Media Bar
- [ ] Verify fallback to global playlist when user has no recommendation playlist yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)