### PR TITLE
feat: per-user recommendation engine for the Media Bar

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,34 @@
+name: Build Plugin
+
+on:
+  push:
+    branches: [feature/per-user-recommendations, main]
+    paths-ignore: ["**.md"]
+  pull_request:
+    paths-ignore: ["**.md"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Build with JPRM
+        id: jprm
+        uses: oddstr13/jellyfin-plugin-repository-manager@v1.1.1
+        with:
+          dotnet-target: net9.0
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact
+          path: ${{ steps.jprm.outputs.artifact }}
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,31 @@
+name: Publish Plugin
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Build with JPRM
+        id: jprm
+        uses: oddstr13/jellyfin-plugin-repository-manager@v1.1.1
+        with:
+          dotnet-target: net9.0
+
+      - name: Upload artifact to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.jprm.outputs.artifact }}

--- a/Jellyfin.Plugin.MediaBar.sln
+++ b/Jellyfin.Plugin.MediaBar.sln
@@ -1,0 +1,19 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.MediaBar", "src\Jellyfin.Plugin.MediaBar\Jellyfin.Plugin.MediaBar.csproj", "{08F615EA-2107-4F04-89CC-091035F54448}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{08F615EA-2107-4F04-89CC-091035F54448}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08F615EA-2107-4F04-89CC-091035F54448}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08F615EA-2107-4F04-89CC-091035F54448}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08F615EA-2107-4F04-89CC-091035F54448}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,19 @@
+---
+name: "Media Bar"
+guid: "08f615ea-2107-4f04-89cc-091035f54448"
+version: "2.5.0.0"
+targetAbi: "10.11.0.0"
+framework: "net9.0"
+overview: "Adds a featured content bar to the Jellyfin home page with per-user recommendations."
+description: >
+  Adds a customizable media showcase bar to the Jellyfin home page.
+  Includes a built-in recommendation engine that scores each user's
+  unwatched movies (rating, genre affinity, recency) and displays
+  personalized content per user.
+category: "General"
+owner: "Jycreyn"
+artifacts:
+  - "Jellyfin.Plugin.MediaBar.dll"
+changelog: >
+  Add per-user recommendation engine. Each user now gets personalized
+  movie suggestions in the Media Bar based on their watch history.

--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -811,28 +811,51 @@ const ApiUtils = {
   },
 
   /**
-   * Fetch item IDs from the list file
-   * @returns {Promise<Array>} Array of item IDs
+   * Fetch item IDs via the MediaBar backend, which applies per-user recommendation
+   * logic before falling back to list.txt or the configured playlist.
+   * @returns {Promise<{ids: Array, isRecommendation: boolean}>}
    */
   async fetchItemIdsFromList() {
     try {
-      const listFileName = `${STATE.jellyfinData.serverAddress}/web/avatars/list.txt?userId=${STATE.jellyfinData.userId}`;
-      const response = await fetch(listFileName);
-
-      if (!response.ok) {
-        console.warn("list.txt not found or inaccessible. Using random items.");
-        return [];
+      // Fetch list.txt so we can pass it to the backend as a fallback payload
+      const listFileName = `${STATE.jellyfinData.serverAddress}/web/avatars/list.txt`;
+      let listContents = "";
+      try {
+        const listResponse = await fetch(listFileName);
+        if (listResponse.ok) {
+          listContents = await listResponse.text();
+        }
+      } catch (_) {
+        // list.txt absent — backend will use the configured playlist or random
       }
 
-      const text = await response.text();
-      return text
-        .split("\n")
-        .map((id) => id.trim())
-        .filter((id) => id)
-        .slice(1);
+      // POST to MediaBar/Avatar/List — the backend injects recommendations when enabled
+      const recoResponse = await fetch(
+        `${STATE.jellyfinData.serverAddress}/MediaBar/Avatar/List`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...this.getAuthHeaders(),
+          },
+          body: JSON.stringify({ contents: listContents }),
+        },
+      );
+
+      if (!recoResponse.ok) {
+        console.warn("MediaBar/Avatar/List unavailable, falling back to list.txt.");
+        return { ids: listContents.split("\n").map((id) => id.trim()).filter(Boolean).slice(1), isRecommendation: false };
+      }
+
+      const text = await recoResponse.text();
+      const lines = text.split("\n").map((id) => id.trim()).filter(Boolean);
+      const playlistName = lines[0] ?? "";
+      const ids = lines.slice(1);
+      const isRecommendation = playlistName.startsWith("_mbr_");
+      return { ids, isRecommendation };
     } catch (error) {
-      console.error("Error fetching list.txt:", error);
-      return [];
+      console.error("Error fetching item list:", error);
+      return { ids: [], isRecommendation: false };
     }
   },
 
@@ -2081,13 +2104,17 @@ const SlideshowManager = {
     try {
       STATE.slideshow.isLoading = true;
 
-      let itemIds = await ApiUtils.fetchItemIdsFromList();
+      const { ids: fetchedIds, isRecommendation } = await ApiUtils.fetchItemIdsFromList();
+      let itemIds = fetchedIds;
 
       if (itemIds.length === 0) {
         itemIds = await ApiUtils.fetchItemIdsFromServer();
       }
 
-      itemIds = SlideUtils.shuffleArray(itemIds);
+      // Preserve recommendation order; shuffle everything else
+      if (!isRecommendation) {
+        itemIds = SlideUtils.shuffleArray(itemIds);
+      }
 
       STATE.slideshow.itemIds = itemIds;
       STATE.slideshow.totalItems = itemIds.length;

--- a/src/Jellyfin.Plugin.MediaBar/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Configuration/PluginConfiguration.cs
@@ -13,11 +13,24 @@ namespace Jellyfin.Plugin.MediaBar.Configuration
         public MediaBarState Enabled { get; set; } = MediaBarState.Enabled;
 
         public string VersionString { get; set; } = "main";
-        
+
         public bool UseAvatarsFile { get; set; } = true;
 
         public string AvatarsPlaylist { get; set; } = string.Empty;
-        
+
+        // Recommendation engine settings
+        public bool RecommendationsEnabled { get; set; } = false;
+
+        public int RecommendationTopN { get; set; } = 15;
+
+        public double RecommendationRatingWeight { get; set; } = 0.3;
+
+        public double RecommendationGenreWeight { get; set; } = 0.6;
+
+        public double RecommendationRecencyWeight { get; set; } = 0.1;
+
+        public int RecommendationRecencyDays { get; set; } = 90;
+
         public WebConfig WebConfig { get; set; } = new WebConfig();
     }
 

--- a/src/Jellyfin.Plugin.MediaBar/Configuration/config.html
+++ b/src/Jellyfin.Plugin.MediaBar/Configuration/config.html
@@ -20,6 +20,7 @@
         <div style="margin-bottom: 1.5em;">
             <button class="jellyfin-tab-button active" data-tab="general" style="background: none; border: none; color: #fff; cursor: pointer; transition: color 0.3s, border-bottom 0.3s; border-bottom: 2px solid #fff; padding: 0.5em 1em;"><h3>General Settings</h3></button>
             <button class="jellyfin-tab-button" data-tab="web-config" style="background: none; border: none; color: #ccc; cursor: pointer; transition: color 0.3s, border-bottom 0.3s; border-bottom: 2px solid transparent; padding: 0.5em 1em;"><h3>Web Config Settings</h3></button>
+            <button class="jellyfin-tab-button" data-tab="recommendations" style="background: none; border: none; color: #ccc; cursor: pointer; transition: color 0.3s, border-bottom 0.3s; border-bottom: 2px solid transparent; padding: 0.5em 1em;"><h3>Recommendations</h3></button>
         </div>
 
         <form class="mediaBarConfigurationForm">
@@ -145,6 +146,50 @@
                     </div>
                 </div>
             </div>
+            <div id="recommendations" class="jellyfin-tab-content" style="display: none;">
+                <div class="inputContainer" style="margin-bottom:1em;">
+                    <p class="fieldDescription">When enabled, a daily task scores each user's unwatched movies (rating, genre affinity, recency) and generates a personalized playlist for the Media Bar. Each user sees different content.<br/>Make sure to disable "Use physical avatars file" and run the task at least once.</p>
+                </div>
+                <div class="checkboxContainer checkboxContainer-withDescription" style="margin-bottom: 1.5em;">
+                    <label class="emby-checkbox-label">
+                        <input type="checkbox" id="chkRecommendationsEnabled" is="emby-checkbox" class="emby-checkbox" data-id="chkRecommendationsEnabled" />
+                        <span class="checkboxLabel">Enable per-user recommendations</span>
+                        <span class="checkboxOutline">
+                            <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+                            <span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
+                        </span>
+                    </label>
+                    <div class="fieldDescription">Generate personalized recommendations for each user based on their watch history.</div>
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="numTopN">Number of items per user</label>
+                    <input id="numTopN" type="number" is="emby-input" class="emby-input" data-id="numTopN" min="5" max="50" />
+                    <div class="fieldDescription">How many movies to include in each user's recommendation playlist (5–50).</div>
+                </div>
+                <br/>
+                <h3 style="margin-bottom: 0.5em;">Scoring weights</h3>
+                <p class="fieldDescription" style="margin-bottom:1em;">Each factor contributes independently — they don't need to sum to 1.</p>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="numRatingWeight">Community rating weight</label>
+                    <input id="numRatingWeight" type="number" is="emby-input" class="emby-input" data-id="numRatingWeight" min="0" max="1" step="0.05" />
+                    <div class="fieldDescription">Importance of the IMDB/TMDB score (0 = ignored, 1 = strong).</div>
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="numGenreWeight">Genre affinity weight</label>
+                    <input id="numGenreWeight" type="number" is="emby-input" class="emby-input" data-id="numGenreWeight" min="0" max="1" step="0.05" />
+                    <div class="fieldDescription">Importance of matching genres from the user's watch history.</div>
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="numRecencyWeight">Recency weight</label>
+                    <input id="numRecencyWeight" type="number" is="emby-input" class="emby-input" data-id="numRecencyWeight" min="0" max="1" step="0.05" />
+                    <div class="fieldDescription">Bonus for movies recently added to the library.</div>
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="numRecencyDays">Recency window (days)</label>
+                    <input id="numRecencyDays" type="number" is="emby-input" class="emby-input" data-id="numRecencyDays" min="7" max="365" />
+                    <div class="fieldDescription">Movies added within this many days are eligible for the recency bonus.</div>
+                </div>
+            </div>
             <br />
             <button id="saveConfig" is="emby-button" type="submit" class="emby-button raised button-submit block">
                 <span>Save</span>
@@ -191,6 +236,12 @@
                         UseAvatarsFile: document.querySelector("[data-id=chkUseAvatarsFile]").checked,
                         AvatarsPlaylist: document.querySelector("[data-id=txtAvatarsPlaylist]").value,
                         VersionString: document.querySelector("[data-id=txtVersionString]").value,
+                        RecommendationsEnabled: document.querySelector("[data-id=chkRecommendationsEnabled]").checked,
+                        RecommendationTopN: parseInt(document.querySelector("[data-id=numTopN]").value, 10),
+                        RecommendationRatingWeight: parseFloat(document.querySelector("[data-id=numRatingWeight]").value),
+                        RecommendationGenreWeight: parseFloat(document.querySelector("[data-id=numGenreWeight]").value),
+                        RecommendationRecencyWeight: parseFloat(document.querySelector("[data-id=numRecencyWeight]").value),
+                        RecommendationRecencyDays: parseInt(document.querySelector("[data-id=numRecencyDays]").value, 10),
                         WebConfig: {
                             ImageSvgs: {
                                 ImdbLogo: null,
@@ -248,6 +299,12 @@
                             document.querySelector("[data-id=numFadeTransitionDuration]").value = config.WebConfig.FadeTransitionDuration;
                             document.querySelector("[data-id=chkSlideAnimationEnabled]").checked = config.WebConfig.SlideAnimationEnabled;
                             document.querySelector("[data-id=chkEnableTrailers]").checked = config.WebConfig.EnableTrailers;
+                            document.querySelector("[data-id=chkRecommendationsEnabled]").checked = config.RecommendationsEnabled || false;
+                            document.querySelector("[data-id=numTopN]").value = config.RecommendationTopN || 15;
+                            document.querySelector("[data-id=numRatingWeight]").value = config.RecommendationRatingWeight != null ? config.RecommendationRatingWeight : 0.3;
+                            document.querySelector("[data-id=numGenreWeight]").value = config.RecommendationGenreWeight != null ? config.RecommendationGenreWeight : 0.6;
+                            document.querySelector("[data-id=numRecencyWeight]").value = config.RecommendationRecencyWeight != null ? config.RecommendationRecencyWeight : 0.1;
+                            document.querySelector("[data-id=numRecencyDays]").value = config.RecommendationRecencyDays || 90;
                         })
                         .catch(function (error) {
                             console.error(error);

--- a/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
@@ -1,13 +1,17 @@
-﻿using System.Reflection;
+﻿using System.Globalization;
+using System.Reflection;
+using System.Security.Claims;
 using System.Text.RegularExpressions;
 using Jellyfin.Extensions;
 using Jellyfin.Plugin.MediaBar.Attributes;
 using Jellyfin.Plugin.MediaBar.Configuration;
 using Jellyfin.Plugin.MediaBar.Model;
+using Jellyfin.Plugin.MediaBar.ScheduledTasks;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Playlists;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Jellyfin.Plugin.MediaBar.Helpers
@@ -24,11 +28,31 @@ namespace Jellyfin.Plugin.MediaBar.Helpers
         
         private static string? AvatarsList(PatchRequestPayload payload, IPlaylistManager playlistManager, IUserManager userManager)
         {
+            // Recommendations take priority over all other sources
+            if (MediaBarPlugin.Instance.Configuration.RecommendationsEnabled)
+            {
+                Guid? requestingUserId = GetRequestingUserId();
+                if (requestingUserId.HasValue)
+                {
+                    string recoName = UpdateRecommendationsTask.PlaylistPrefix
+                        + requestingUserId.Value.ToString("N", CultureInfo.InvariantCulture);
+
+                    Playlist? recoPlaylist = playlistManager.GetPlaylists(requestingUserId.Value)
+                        .FirstOrDefault(x => x.Name == recoName);
+
+                    if (recoPlaylist is not null)
+                    {
+                        return BuildPlaylistResponse(recoPlaylist, requestingUserId.Value, userManager, shuffle: false);
+                    }
+                }
+            }
+
             if (MediaBarPlugin.Instance.Configuration.UseAvatarsFile)
             {
                 return payload.Contents;
             }
-            
+
+            // Fall back to the globally configured playlist (existing behaviour)
             IEnumerable<Guid> allUserIds = userManager.UsersIds;
 
             Playlist? playlist = null;
@@ -51,15 +75,19 @@ namespace Jellyfin.Plugin.MediaBar.Helpers
                 return payload.Contents;
             }
 
+            return BuildPlaylistResponse(playlist, userIdToUse.Value, userManager, shuffle: true);
+        }
+
+        private static string BuildPlaylistResponse(Playlist playlist, Guid userId, IUserManager userManager, bool shuffle)
+        {
             IEnumerable<Tuple<LinkedChild, BaseItem>> itemsRaw = playlist.GetManageableItems()
-                .Where(i => i.Item2.IsVisible(userManager.GetUserById(userIdToUse.Value)));
+                .Where(i => i.Item2.IsVisible(userManager.GetUserById(userId)));
 
             StringWriter stringWriter = new StringWriter();
+            stringWriter.WriteLine(playlist.Name);
 
-            stringWriter.WriteLine(MediaBarPlugin.Instance.Configuration.AvatarsPlaylist);
-                
             List<Guid> idsWritten = new List<Guid>();
-                
+
             foreach (Tuple<LinkedChild, BaseItem> item in itemsRaw)
             {
                 BaseItem itemToUse = item.Item2;
@@ -74,15 +102,43 @@ namespace Jellyfin.Plugin.MediaBar.Helpers
                 }
             }
 
-            idsWritten.Shuffle();
+            if (shuffle)
+            {
+                idsWritten.Shuffle();
+            }
 
             foreach (Guid id in idsWritten)
             {
                 // For some reason the JF api doesn't treat GUIDs correctly
                 stringWriter.WriteLine(id.ToString().Replace("-", ""));
             }
-            
+
             return stringWriter.ToString();
+        }
+
+        private static Guid? GetRequestingUserId()
+        {
+            try
+            {
+                IHttpContextAccessor httpContextAccessor =
+                    MediaBarPlugin.Instance.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
+
+                string? userIdString = httpContextAccessor.HttpContext?.User
+                    ?.FindFirst("Jellyfin-userId")?.Value
+                    ?? httpContextAccessor.HttpContext?.User
+                    ?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+                if (Guid.TryParse(userIdString, out Guid userId))
+                {
+                    return userId;
+                }
+            }
+            catch
+            {
+                // IHttpContextAccessor not available — not critical, fall through to global playlist
+            }
+
+            return null;
         }
         
         public static string IndexHtml(PatchRequestPayload payload)

--- a/src/Jellyfin.Plugin.MediaBar/PluginServiceRegistrator.cs
+++ b/src/Jellyfin.Plugin.MediaBar/PluginServiceRegistrator.cs
@@ -1,6 +1,8 @@
-﻿using Jellyfin.Plugin.MediaBar.Services;
+﻿using Jellyfin.Plugin.MediaBar.ScheduledTasks;
+using Jellyfin.Plugin.MediaBar.Services;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
+using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Jellyfin.Plugin.MediaBar
@@ -9,6 +11,8 @@ namespace Jellyfin.Plugin.MediaBar
     {
         public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
         {
+            serviceCollection.AddHttpContextAccessor();
+            serviceCollection.AddSingleton<IScheduledTask, UpdateRecommendationsTask>();
         }
     }
 }

--- a/src/Jellyfin.Plugin.MediaBar/ScheduledTasks/UpdateRecommendationsTask.cs
+++ b/src/Jellyfin.Plugin.MediaBar/ScheduledTasks/UpdateRecommendationsTask.cs
@@ -1,0 +1,193 @@
+using System.Globalization;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.MediaBar.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Playlists;
+using MediaBrowser.Model.Querying;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.MediaBar.ScheduledTasks
+{
+    public class UpdateRecommendationsTask : IScheduledTask
+    {
+        // Internal playlist name prefix — one playlist per user, not meant to be manually configured
+        internal const string PlaylistPrefix = "_mbr_";
+
+        private readonly ILibraryManager _libraryManager;
+        private readonly IUserManager _userManager;
+        private readonly IUserDataManager _userDataManager;
+        private readonly IPlaylistManager _playlistManager;
+        private readonly ILogger<UpdateRecommendationsTask> _logger;
+
+        public UpdateRecommendationsTask(
+            ILibraryManager libraryManager,
+            IUserManager userManager,
+            IUserDataManager userDataManager,
+            IPlaylistManager playlistManager,
+            ILogger<UpdateRecommendationsTask> logger)
+        {
+            _libraryManager = libraryManager;
+            _userManager = userManager;
+            _userDataManager = userDataManager;
+            _playlistManager = playlistManager;
+            _logger = logger;
+        }
+
+        public string Name => "Update Media Bar Recommendations";
+        public string Key => "MediaBar.UpdateRecommendations";
+        public string Description => "Generates per-user personalized movie recommendations and updates the Media Bar featured playlist for each user.";
+        public string Category => "Media Bar";
+
+        public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+        {
+            var config = MediaBarPlugin.Instance.Configuration;
+
+            if (!config.RecommendationsEnabled)
+            {
+                _logger.LogInformation("[MediaBar] Recommendations disabled, skipping.");
+                return;
+            }
+
+            var allUsers = _userManager.Users.ToList();
+            if (allUsers.Count == 0)
+            {
+                return;
+            }
+
+            double step = 100.0 / allUsers.Count;
+
+            for (int i = 0; i < allUsers.Count; i++)
+            {
+                var user = allUsers[i];
+                cancellationToken.ThrowIfCancellationRequested();
+
+                _logger.LogInformation("[MediaBar] Generating recommendations for user '{User}'.", user.Username);
+
+                try
+                {
+                    await UpdateForUser(user.Id, config).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "[MediaBar] Failed to update recommendations for user '{User}'.", user.Username);
+                }
+
+                progress.Report((i + 1) * step);
+            }
+        }
+
+        private async Task UpdateForUser(Guid userId, PluginConfiguration config)
+        {
+            var user = _userManager.GetUserById(userId);
+            if (user is null)
+            {
+                return;
+            }
+
+            // All movies visible to this user
+            var allMovies = _libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = [BaseItemKind.Movie],
+                IsVirtualItem = false,
+                Recursive = true
+            });
+
+            var watched = allMovies
+                .Where(m => _userDataManager.GetUserData(user, m).Played)
+                .ToList();
+
+            var unwatched = allMovies
+                .Where(m => !_userDataManager.GetUserData(user, m).Played)
+                .ToList();
+
+            // Genre frequency map from watch history (percentage-based: count / total watched)
+            var genreFreq = watched
+                .SelectMany(m => m.Genres ?? [])
+                .GroupBy(g => g, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.OrdinalIgnoreCase);
+
+            double totalWatched = watched.Count > 0 ? watched.Count : 1;
+
+            var now = DateTime.UtcNow;
+            var topIds = unwatched
+                .Select(movie =>
+                {
+                    double score = 0;
+
+                    if (movie.CommunityRating.HasValue)
+                        score += (movie.CommunityRating.Value / 10.0) * config.RecommendationRatingWeight;
+
+                    if (movie.Genres is { Length: > 0 })
+                    {
+                        // Sum percentage affinity across all matching genres — no cap, rewards multi-genre matches
+                        var genreScore = movie.Genres
+                            .Where(g => genreFreq.ContainsKey(g))
+                            .Sum(g => genreFreq[g] / totalWatched);
+                        score += genreScore * config.RecommendationGenreWeight;
+                    }
+
+                    var age = (now - movie.DateCreated).TotalDays;
+                    if (age is >= 0 and <= 365)
+                    {
+                        var window = (double)config.RecommendationRecencyDays;
+                        if (age <= window)
+                            score += (1.0 - age / window) * config.RecommendationRecencyWeight;
+                    }
+
+                    return (Id: movie.Id, Score: score);
+                })
+                .OrderByDescending(x => x.Score)
+                .Take(config.RecommendationTopN)
+                .Select(x => x.Id)
+                .ToArray();
+
+            // Internal playlist name for this user
+            string playlistName = PlaylistPrefix + userId.ToString("N", CultureInfo.InvariantCulture);
+
+            var existing = _libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = [BaseItemKind.Playlist],
+                Name = playlistName,
+                Recursive = true
+            }).FirstOrDefault() as Playlist;
+
+            if (existing is not null)
+            {
+                var entryIds = existing.LinkedChildren
+                    .Where(c => c.ItemId.HasValue)
+                    .Select(c => c.ItemId!.Value.ToString("N", CultureInfo.InvariantCulture))
+                    .ToList();
+
+                if (entryIds.Count > 0)
+                    await _playlistManager.RemoveItemFromPlaylistAsync(existing.Id.ToString(), entryIds).ConfigureAwait(false);
+
+                await _playlistManager.AddItemToPlaylistAsync(existing.Id, topIds, userId).ConfigureAwait(false);
+            }
+            else
+            {
+                await _playlistManager.CreatePlaylist(new PlaylistCreationRequest
+                {
+                    Name = playlistName,
+                    ItemIdList = topIds,
+                    UserId = userId,
+                    MediaType = MediaType.Video
+                }).ConfigureAwait(false);
+            }
+
+            _logger.LogInformation("[MediaBar] Playlist updated for user '{User}' with {Count} recommendations.", user.Username, topIds.Length);
+        }
+
+        public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() =>
+        [
+            new TaskTriggerInfo
+            {
+                Type = TaskTriggerInfoType.DailyTrigger,
+                TimeOfDayTicks = TimeSpan.FromHours(3).Ticks
+            }
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a nightly scheduled task that generates a personalized playlist (`_mbr_<userId>`) for each Jellyfin user based on their watch history
- Scoring combines community rating (×0.3), genre affinity (×0.6) and recency (×0.1) — genre affinity uses percentage-based normalization without a cap so multi-genre matches rank higher
- Recommendations take priority over `UseAvatarsFile` / `AvatarsPlaylist` when a valid per-user playlist exists; user identity is resolved from the `Jellyfin-UserId` JWT claim
- Fixes `slideshowpure.js` to POST to `/MediaBar/Avatar/List` (with auth token) instead of reading `list.txt` directly, so the backend can inject the right playlist per user
- All weights, `TopN` (default 15) and recency window (default 90 days) are configurable from a new **Recommendations** tab in the plugin settings
- Also adds JPRM-compatible CI workflows (build on push/PR, publish on tag)

## How it works

1. Admin enables recommendations in plugin settings and disables "Use physical avatars file"
2. The scheduled task runs (or is triggered manually) — it scores each user's unwatched movies and stores a `_mbr_<userId>` playlist
3. When a user loads the home page, `slideshowpure.js` calls `POST /MediaBar/Avatar/List` with the auth token; the server finds the user's playlist and returns the ordered IDs
4. The Media Bar displays the personalized top 15 in score order

## Test plan

- [ ] Enable recommendations in plugin settings, run the scheduled task manually
- [ ] Verify each user sees different films based on their watch history
- [ ] Verify fallback to `list.txt` / `AvatarsPlaylist` still works when recommendations are disabled
- [ ] Verify a user with no watch history doesn't cause errors (falls back gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)