### PR TITLE
fix: replace removed IUserManager.UsersIds property with GetUsersIds() for Jellyfin 10.11.9

### DIFF
--- a/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
@@ -29,7 +29,7 @@ namespace Jellyfin.Plugin.MediaBar.Helpers
                 return payload.Contents;
             }
             
-            IEnumerable<Guid> allUserIds = userManager.UsersIds;
+            IEnumerable<Guid> allUserIds = userManager.GetUsersIds();
 
             Playlist? playlist = null;
             Guid? userIdToUse = null;

--- a/src/Jellyfin.Plugin.MediaBar/Jellyfin.Plugin.MediaBar.csproj
+++ b/src/Jellyfin.Plugin.MediaBar/Jellyfin.Plugin.MediaBar.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <JellyfinVersion>10.11.2</JellyfinVersion>
+        <JellyfinVersion>10.11.9</JellyfinVersion>
         <JellyfinNugetVersion Condition="!$(JellyfinVersion.StartsWith('10.11'))">$(JellyfinVersion)</JellyfinNugetVersion>
         <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('10.11'))">$(JellyfinVersion)</JellyfinNugetVersion>
         <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('10.11.1'))">10.11.0</JellyfinNugetVersion>


### PR DESCRIPTION
## Summary

`IUserManager.UsersIds` (property getter) was removed in Jellyfin 10.11.9, causing the plugin to throw `MissingMethodException` at startup on any instance running 10.11.9+.

**Changes:**
- `TransformationPatches.cs`: `userManager.UsersIds` → `userManager.GetUsersIds()`
- `.csproj`: NuGet target bumped from `10.11.2` to `10.11.9`

## Error fixed

```
System.MissingMethodException: Method not found:
'System.Collections.Generic.IEnumerable`1<System.Guid>
MediaBrowser.Controller.Library.IUserManager.get_UsersIds()'
```

## Test plan

- [x] Compiled against Jellyfin 10.11.9 NuGet packages — 0 errors
- [x] Deployed to Jellyfin 10.11.9 — no MissingMethodException on startup
- [x] Avatars playlist feature loads correctly