### PR TITLE
Fix backdrop/trailer mask blend in Firefox (invalid mask-composite value)

### DIFF
--- a/slideshowpure.css
+++ b/slideshowpure.css
@@ -421,7 +421,7 @@
     linear-gradient(to top, #fff0 2%, rgb(0 0 0 / 0.5) 6%, #000000 8%),
     linear-gradient(to right, black 30%, transparent 85%);
 
-  mask-composite: source-in;
+  mask-composite: intersect;
   -webkit-mask-composite: source-in;
 }
 


### PR DESCRIPTION
## Problem

The backdrop poster should fade smoothly into the trailer video on the featured spotlight. Firefox skips the fade and shows a hard vertical seam instead. Chromium renders it correctly.

## Cause

In `.backdrop.with-video`, the mask layers are combined with:

```css
mask-composite: source-in;
-webkit-mask-composite: source-in;
```

`source-in` is valid for `-webkit-mask-composite` but not for the standard `mask-composite`, which only accepts `add | subtract | intersect | exclude`. Chromium uses the webkit line and works. Firefox parses the standard line, finds `source-in` invalid, drops it, and falls back to the default `add`. That unions the mask layers instead of intersecting them, so the fade disappears.

`intersect` is the standard equivalent of webkit's `source-in`. The other rules in this file (`.video-container`) already use it.

## Fix

Set the standard property to `intersect`. The `-webkit-mask-composite` line is unchanged, so Chromium behavior stays the same.

## Testing

Confirmed in Firefox: `source-in` gives a hard seam, `intersect` gives the intended fade. Chromium rendering unchanged.
