### PR TITLE
Show "Ends at" time in the viewer's own clock format

### DIFF
--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -1384,7 +1384,7 @@ const SlideCreator = {
         const milliseconds = runtime / 10000;
         const currentTime = new Date();
         const endTime = new Date(currentTime.getTime() + milliseconds);
-        const options = { hour: "2-digit", minute: "2-digit", hour12: false };
+        const options = { hour: "2-digit", minute: "2-digit" };
         const formattedEndTime = endTime.toLocaleTimeString([], options);
         const endsAtText = LocalizationUtils.getLocalizedString(
           "EndsAtValue",


### PR DESCRIPTION
Right now the end time is locked to 24-hour. There is no option to switch to 12 hour. Dropping the forced setting lets it match whatever the viewer's device already uses including 12 hr with AM/PM along with the existing 24 hour format.