### PR TITLE
Sync slideshowpure.js with MakD v5.0.1

### DIFF
--- a/slideshowpure.css
+++ b/slideshowpure.css
@@ -1,5 +1,5 @@
 /*
- * Jellyfin Slideshow by M0RPH3US v4.0.6
+ * Jellyfin Slideshow by M0RPH3US v5.0.1
  */
 
 @import url(https://fonts.googleapis.com/css2?family=Archivo+Narrow:ital,wght@0,400..700;1,400..700&display=swap);

--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -1,5 +1,5 @@
 /*
- * Jellyfin Slideshow by M0RPH3US v4.0.6
+ * Jellyfin Slideshow by M0RPH3US v5.0.1
  */
 
 //Core Module Configuration

--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -22,6 +22,7 @@ const CONFIG = {
   fadeTransitionDuration: 500,
   slideAnimationEnabled: true,
   enableTrailers: true,
+  youtubeApiLoadTimeoutMs: 8000,
 };
 
 // State management
@@ -63,13 +64,45 @@ const loadYouTubeAPI = () => {
       resolve(window.YT);
       return;
     }
-    window.onYouTubeIframeAPIReady = () => resolve(window.YT);
-    if (!document.querySelector('script[src*="youtube.com/iframe_api"]')) {
-      const tag = document.createElement("script");
+
+    let timeout;
+    let settled = false;
+    const previousReady = window.onYouTubeIframeAPIReady;
+    const finish = (YT = null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve(YT && YT.Player ? YT : null);
+    };
+
+    window.onYouTubeIframeAPIReady = () => {
+      if (typeof previousReady === "function") {
+        previousReady();
+      }
+      finish(window.YT);
+    };
+
+    let tag = document.querySelector('script[src*="youtube.com/iframe_api"]');
+    if (!tag) {
+      tag = document.createElement("script");
       tag.src = "https://www.youtube.com/iframe_api";
+      tag.async = true;
+      tag.onerror = () => {
+        console.warn(
+          "YouTube iframe API failed to load; continuing without trailers.",
+        );
+        finish();
+      };
       const firstScriptTag = document.getElementsByTagName("script")[0];
       firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
     }
+
+    timeout = setTimeout(() => {
+      console.warn(
+        "Timed out loading YouTube iframe API; continuing without trailers.",
+      );
+      finish();
+    }, CONFIG.youtubeApiLoadTimeoutMs);
   });
   return STATE.slideshow.ytPromise;
 };
@@ -374,7 +407,9 @@ const waitForApiClientAndInitialize = () => {
         initJellyfinData(async () => {
           console.log("✅ Jellyfin API client initialized successfully");
           await initLocalization();
-          await loadYouTubeAPI();
+          if (CONFIG.enableTrailers) {
+            await loadYouTubeAPI();
+          }
           slidesInit();
         });
       } else {
@@ -1517,6 +1552,7 @@ const SlideCreator = {
         const startTime = await ApiUtils.getSkipSegments(videoId);
 
         loadYouTubeAPI().then((YT) => {
+          if (!YT) return;
           if (!document.getElementById(`trailer-${itemId}`)) return;
 
           STATE.slideshow.players[itemId] = new YT.Player(


### PR DESCRIPTION
Merges the current MakD main into this fork. It applies cleanly with no conflicts, so this should be a straight merge on your side.

Four commits come across, and only one of them changes behaviour:

- `74873bf` Fallback when YouTube API fails to load (MakD #110)
- `f2f5846` merge commit for the above
- `57e33f5` version bump to v5.0.1
- `073eac7` version bump in the CSS

The first is the one worth having. Without it a failed or slow YouTube iframe API load can leave the slideshow waiting rather than carrying on without trailers, which tends to surface as "the bar does not load" for anyone on a network where YouTube is slow or blocked. It also brings a configurable timeout, `CONFIG.youtubeApiLoadTimeoutMs`.

Net effect is +42/-6 across `slideshowpure.js` and `slideshowpure.css`. I checked that the merged `slideshowpure.js` still parses.

No rush on this at all, and no objection if you would rather do the merge yourself. If it would be useful I am happy to follow up with a small scheduled workflow that keeps the two in step, but only if you want one.

For transparency, I have a couple of PRs open at MakD, so I have some interest in the two staying in step.