### PR TITLE
Serve slideshowpure.js/css from the plugin instead of jsDelivr

### DIFF
--- a/src/Jellyfin.Plugin.MediaBar/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Configuration/PluginConfiguration.cs
@@ -10,10 +10,12 @@ namespace Jellyfin.Plugin.MediaBar.Configuration
     
     public class PluginConfiguration : BasePluginConfiguration
     {
+        public const string EmbeddedVersion = "embedded";
+
         public MediaBarState Enabled { get; set; } = MediaBarState.Enabled;
 
-        public string VersionString { get; set; } = "main";
-        
+        public string VersionString { get; set; } = EmbeddedVersion;
+
         public bool UseAvatarsFile { get; set; } = true;
 
         public string AvatarsPlaylist { get; set; } = string.Empty;

--- a/src/Jellyfin.Plugin.MediaBar/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Configuration/PluginConfiguration.cs
@@ -16,6 +16,18 @@ namespace Jellyfin.Plugin.MediaBar.Configuration
 
         public string VersionString { get; set; } = EmbeddedVersion;
 
+        public static bool UsesEmbeddedAssets(string? version)
+        {
+            version = version?.Trim();
+
+            // main/latest predate the embedded assets; configs that saved them meant
+            // "newest", which is now the embedded copy
+            return string.IsNullOrWhiteSpace(version) ||
+                   string.Equals(version, EmbeddedVersion, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(version, "main", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase);
+        }
+
         public bool UseAvatarsFile { get; set; } = true;
 
         public string AvatarsPlaylist { get; set; } = string.Empty;

--- a/src/Jellyfin.Plugin.MediaBar/Configuration/config.html
+++ b/src/Jellyfin.Plugin.MediaBar/Configuration/config.html
@@ -37,7 +37,7 @@
                         <label class="inputLabel inputLabelUnfocused" for="txtVersionString">Version</label>
                         <label class="inputLabel inputLabel-float inputLabelUnfocused" for="txtVersionString"></label>
                         <input id="txtVersionString" type="text" is="emby-input" class="emby-input" data-id="txtVersionString" />
-                        <div class="fieldDescription">Which version of the jsdelivr'd plugin should be used.</div>
+                        <div class="fieldDescription">Where the web assets are loaded from. Leave as <code>embedded</code> to serve the copies shipped inside this plugin, which always match the installed version and need no internet access. Set a git ref (branch, tag or commit) to load that version from jsDelivr instead.</div>
                     </div>
                     <div class="checkboxContainer checkboxContainer-withDescription">
                         <label class="emby-checkbox-label">

--- a/src/Jellyfin.Plugin.MediaBar/Configuration/config.html
+++ b/src/Jellyfin.Plugin.MediaBar/Configuration/config.html
@@ -37,7 +37,7 @@
                         <label class="inputLabel inputLabelUnfocused" for="txtVersionString">Version</label>
                         <label class="inputLabel inputLabel-float inputLabelUnfocused" for="txtVersionString"></label>
                         <input id="txtVersionString" type="text" is="emby-input" class="emby-input" data-id="txtVersionString" />
-                        <div class="fieldDescription">Where the web assets are loaded from. Leave as <code>embedded</code> to serve the copies shipped inside this plugin, which always match the installed version and need no internet access. Set a git ref (branch, tag or commit) to load that version from jsDelivr instead.</div>
+                        <div class="fieldDescription">Where the web assets are loaded from. <code>embedded</code> (also <code>main</code>, <code>latest</code>, or blank) serves the copies shipped inside this plugin, which always match the installed version and need no internet access. Set a tag or commit to load that exact version from jsDelivr instead.</div>
                     </div>
                     <div class="checkboxContainer checkboxContainer-withDescription">
                         <label class="emby-checkbox-label">
@@ -229,10 +229,6 @@
                             document.querySelector("[data-id=enabledSelect]").value = config.Enabled;
                             document.querySelector("[data-id=chkUseAvatarsFile]").checked = config.UseAvatarsFile;
                             document.querySelector("[data-id=txtAvatarsPlaylist]").value = config.AvatarsPlaylist;
-                            
-                            if (config.VersionString === 'latest') {
-                                config.VersionString = 'main';
-                            }
                             
                             document.querySelector("[data-id=txtVersionString]").value = config.VersionString;
                             

--- a/src/Jellyfin.Plugin.MediaBar/Controllers/MediaBarController.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Controllers/MediaBarController.cs
@@ -17,9 +17,16 @@ namespace Jellyfin.Plugin.MediaBar.Controllers
         [HttpGet("{file}")]
         public ActionResult GetFile([FromRoute] string file)
         {
-            Stream fileStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Jellyfin.Plugin.MediaBar.Inject." + file)!;
-            string fileContents = new StreamReader(fileStream).ReadToEnd();
-        
+            Stream? fileStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Jellyfin.Plugin.MediaBar.Inject." + file);
+
+            if (fileStream == null)
+            {
+                return NotFound();
+            }
+
+            using StreamReader streamReader = new StreamReader(fileStream);
+            string fileContents = streamReader.ReadToEnd();
+
             string contentType = "text/plain";
 
             if (Path.GetExtension(file) == ".js")

--- a/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
@@ -96,25 +96,31 @@ namespace Jellyfin.Plugin.MediaBar.Helpers
             Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream($"{typeof(MediaBarPlugin).Namespace}.Inject.index.html")!;
             using TextReader reader = new StreamReader(stream);
 
-            if (MediaBarPlugin.Instance.Configuration.VersionString == "latest")
-            {
-                MediaBarPlugin.Instance.Configuration.VersionString = "main";
-            }
-
-            if (MediaBarPlugin.Instance.Configuration.VersionString == "main" &&
-                JellyfinVersionAttribute.GetVersion() == "10.11")
-            {
-                // Force 10.11 branch instead of main for now
-                MediaBarPlugin.Instance.Configuration.VersionString = "10.11";
-            }
-            
             string importedHtml = reader
                 .ReadToEnd()
-                .Replace("{{Config.VersionString}}", MediaBarPlugin.Instance.Configuration.VersionString);
-            
+                .Replace("{{Config.VersionString}}", ResolveVersion());
+
             string regex = Regex.Replace(payload.Contents!, "(</head>)", $"{importedHtml}$1");
-            
+
             return regex;
+        }
+
+        private static string ResolveVersion()
+        {
+            string version = MediaBarPlugin.Instance.Configuration.VersionString;
+
+            if (version == "latest")
+            {
+                version = "main";
+            }
+
+            if (version == "main" && JellyfinVersionAttribute.GetVersion() == "10.11")
+            {
+                // Force 10.11 branch instead of main for now
+                version = "10.11";
+            }
+
+            return version;
         }
 
         public static string HomeHtmlChunk(PatchRequestPayload payload)

--- a/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
@@ -1,7 +1,6 @@
 ﻿using System.Reflection;
 using System.Text.RegularExpressions;
 using Jellyfin.Extensions;
-using Jellyfin.Plugin.MediaBar.Attributes;
 using Jellyfin.Plugin.MediaBar.Configuration;
 using Jellyfin.Plugin.MediaBar.JellyfinVersionSpecific;
 using Jellyfin.Plugin.MediaBar.Model;
@@ -107,24 +106,12 @@ namespace Jellyfin.Plugin.MediaBar.Helpers
 
         private static string ResolveAssetBaseUrl()
         {
-            string version = MediaBarPlugin.Instance.Configuration.VersionString;
+            string version = MediaBarPlugin.Instance.Configuration.VersionString.Trim();
 
-            if (string.IsNullOrWhiteSpace(version) ||
-                string.Equals(version, PluginConfiguration.EmbeddedVersion, StringComparison.OrdinalIgnoreCase))
+            if (PluginConfiguration.UsesEmbeddedAssets(version))
             {
                 // Relative to /web/ so it resolves when Jellyfin is hosted under a base path
                 return "../MediaBar";
-            }
-
-            if (version == "latest")
-            {
-                version = "main";
-            }
-
-            if (version == "main" && JellyfinVersionAttribute.GetVersion() == "10.11")
-            {
-                // Force 10.11 branch instead of main for now
-                version = "10.11";
             }
 
             return $"https://cdn.jsdelivr.net/gh/IAmParadox27/jellyfin-plugin-media-bar@{version}";

--- a/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
@@ -98,16 +98,23 @@ namespace Jellyfin.Plugin.MediaBar.Helpers
 
             string importedHtml = reader
                 .ReadToEnd()
-                .Replace("{{Config.VersionString}}", ResolveVersion());
+                .Replace("{{AssetBaseUrl}}", ResolveAssetBaseUrl());
 
             string regex = Regex.Replace(payload.Contents!, "(</head>)", $"{importedHtml}$1");
 
             return regex;
         }
 
-        private static string ResolveVersion()
+        private static string ResolveAssetBaseUrl()
         {
             string version = MediaBarPlugin.Instance.Configuration.VersionString;
+
+            if (string.IsNullOrWhiteSpace(version) ||
+                string.Equals(version, PluginConfiguration.EmbeddedVersion, StringComparison.OrdinalIgnoreCase))
+            {
+                // Relative to /web/ so it resolves when Jellyfin is hosted under a base path
+                return "../MediaBar";
+            }
 
             if (version == "latest")
             {
@@ -120,7 +127,7 @@ namespace Jellyfin.Plugin.MediaBar.Helpers
                 version = "10.11";
             }
 
-            return version;
+            return $"https://cdn.jsdelivr.net/gh/IAmParadox27/jellyfin-plugin-media-bar@{version}";
         }
 
         public static string HomeHtmlChunk(PatchRequestPayload payload)

--- a/src/Jellyfin.Plugin.MediaBar/Inject/index.html
+++ b/src/Jellyfin.Plugin.MediaBar/Inject/index.html
@@ -1,5 +1,5 @@
-﻿<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/IAmParadox27/jellyfin-plugin-media-bar@{{Config.VersionString}}/slideshowpure.css" />
-<script defer src="https://cdn.jsdelivr.net/gh/IAmParadox27/jellyfin-plugin-media-bar@{{Config.VersionString}}/slideshowpure.js"></script>
+﻿<link rel="stylesheet" href="{{AssetBaseUrl}}/slideshowpure.css" />
+<script defer src="{{AssetBaseUrl}}/slideshowpure.js"></script>
 <script defer>
     if (typeof MediaBarConfigHandler == 'undefined') {
         const MediaBarConfigHandler = {

--- a/src/Jellyfin.Plugin.MediaBar/Jellyfin.Plugin.MediaBar.csproj
+++ b/src/Jellyfin.Plugin.MediaBar/Jellyfin.Plugin.MediaBar.csproj
@@ -53,8 +53,9 @@
     <ItemGroup>
         <None Include="..\..\README.md" />
         <None Include="..\logo.png" CopyToOutputDirectory="Always" />
-        <None Include="..\..\slideshowpure.js" />
-        <None Include="..\..\slideshowpure.css" />
+        <!-- Served by MediaBarController at /MediaBar/slideshowpure.{js,css} -->
+        <EmbeddedResource Include="..\..\slideshowpure.js" LogicalName="Jellyfin.Plugin.MediaBar.Inject.slideshowpure.js" />
+        <EmbeddedResource Include="..\..\slideshowpure.css" LogicalName="Jellyfin.Plugin.MediaBar.Inject.slideshowpure.css" />
     </ItemGroup>
 
     <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="Exists('C:\ProgramData\Jellyfin\Server_10_11\plugins\MediaBar')">


### PR DESCRIPTION
## In short

The media bar's browser-side code currently loads from a CDN that tracks the project's `main` branch, so changes reach every server the day they are merged, with no release, no version, and no way to opt out or roll back. This change ships those files inside the plugin itself, so what runs in the browser is exactly what the installed plugin version shipped, the media bar keeps working on servers without internet access, and a compromise of the CDN or the repo's main branch can no longer push code straight into users' logged-in sessions.

## The problem

The injected `index.html` loads the plugin's own web assets from a CDN at a
branch ref:

```html
<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/IAmParadox27/jellyfin-plugin-media-bar@{{Config.VersionString}}/slideshowpure.css" />
<script defer src="https://cdn.jsdelivr.net/gh/IAmParadox27/jellyfin-plugin-media-bar@{{Config.VersionString}}/slideshowpure.js"></script>
```

`VersionString` defaults to `main`. jsDelivr re-resolves a branch ref roughly
every 12 hours, which has three consequences:

**1. Changes reach every install without a release.** This is not theoretical.
[#174](https://github.com/IAmParadox27/jellyfin-plugin-media-bar/issues/174):
[`c1fa76f`](https://github.com/IAmParadox27/jellyfin-plugin-media-bar/commit/c1fa76f0468364acb2a2ca66613beb972dee4013) ("Sync the page backdrop with the featured slide") merged to `main`
on 2026-08-23 and was in users' browsers the next day. There was no release, no
version bump, and no way to decline it. Ten comments, and the workaround people
settled on is installing a third party's JavaScript injector to set a config
flag at runtime, because the installed DLL predates the feature and its
settings page therefore has no toggle for it. One commenter's summary:

> It was not even in a plugin release, would be much easier to find if it was
> in a new plugin release, not fetched from a remote source

**2. The two halves of the plugin drift apart.** The DLL is versioned and the
browser-side code is not, so an install running `2.4.12.0` is running whatever
`main` happened to be at page load, and the server-side config surface can
never describe client-side behaviour that moves independently of it. That is
the mechanism behind the missing toggle in [#174](https://github.com/IAmParadox27/jellyfin-plugin-media-bar/issues/174).

**3. The CDN and both repos are in every install's trust path.** Whatever
serves `slideshowpure.js` decides what runs inside users' authenticated
sessions. The security section below spells this out.

Separately, the media bar simply does not work today on a server with egress
filtering or no internet access, since the JS lives nowhere but the CDN.

## The security exposure

This is the part that makes the current setup a real risk rather than a
workflow quirk.

`slideshowpure.js` executes same-origin with the Jellyfin web client, inside
authenticated sessions. Script at that position can read the access token from
browser storage and call the API as whoever is logged in. If an administrator
views a page, the script holds the admin API: create users, change
permissions, alter server configuration, add a library pointed at an arbitrary
filesystem path. Jellyfin sends no `Content-Security-Policy`, so nothing
constrains where an injected script may send what it reads.

Today that script arrives from a moving branch ref, so the set of parties who
can put code into every install, within jsDelivr's roughly 12-hour cache
window and with no release or version change, is: anyone who can push to
`main` here, and jsDelivr itself. A compromised maintainer account, a
malicious PR that slips through, or a CDN takeover all reach every
installation the same day, and
[#174](https://github.com/IAmParadox27/jellyfin-plugin-media-bar/issues/174)
shows there is no rollback path when they do. The 2024 polyfill.io incident is
the precedent: an unpinned third-party script's infrastructure changed hands
and served malware to over 100,000 sites, and nobody embedding it had done
anything wrong the day before.

A branch ref also forecloses the standard mitigation: subresource integrity
needs a hash of a fixed artifact, which a moving ref by definition is not.

Embedding collapses the trust path to the release artifact itself. The
JavaScript that runs is the JavaScript that was tagged, reviewed, and
installed, and changing what users run requires publishing a release, the same
bar the DLL already meets.

## The change

`MediaBarController` already serves embedded `Inject.*` resources at
`/MediaBar/{file}`, and both files were already in the project as `<None>`
items, so this is mostly wiring that already existed:

- `slideshowpure.js` / `.css` become `EmbeddedResource` under the `Inject`
  namespace, so they ship in the assembly and are locked to the plugin version.
- `Inject/index.html` templates an asset base URL rather than a bare ref.
- `VersionString` defaults to `embedded`, which resolves to `../MediaBar`,
  relative so it survives a Jellyfin hosted under a base path.
- A saved `main`, `latest` or empty value also resolves to embedded. Without
  this the change helps only fresh installs: every existing server has `main`
  written into its config and would keep fetching a moving ref forever. Those
  values never named a version, they named "newest", and the embedded copy is
  now the newest that matches the installed plugin.
- Any other value is still treated as a git ref and fetched from jsDelivr, so
  an administrator who wants a specific tag or commit keeps that.

Three smaller fixes fall out of touching this code, one commit each:

- `IndexHtml()` was assigning to `Configuration.VersionString` while
  normalising it, so every home page load silently rewrote the administrator's
  saved value and concurrent requests raced over the field. Same resolution,
  computed into a local.
- The `JellyfinVersionAttribute.GetVersion() == "10.11"` fallback is deleted.
  It was already dead (the assembly declares `10.11.2`, and the comparison is
  equality), and it is unreachable once `main` resolves to embedded. The `10.11`
  branch it pointed at was last touched in October 2025.
- `GetFile` null-forgave the resource stream, so a request for a file that is
  not embedded threw instead of answering. It returns `404` now, and disposes
  the reader.

## Why jsDelivr was used, and why embedding fits now

Serving from the CDN was a deliberate choice, not an accident. The plugin
originally embedded these files and served them from `/MediaBar/`;
[`ec3661c`](https://github.com/IAmParadox27/jellyfin-plugin-media-bar/commit/ec3661cbdfdf3cc8202c67b4064103e9cf6bc1e9)
(March 2025) switched to jsDelivr pointed at
[MakD/Jellyfin-Media-Bar](https://github.com/MakD/Jellyfin-Media-Bar), whose
install instructions were already jsDelivr-based. At that time the browser half
lived in a separate repo with its own maintainer and a much faster cadence than
the DLL, so the CDN decoupled the two release cycles: style and script fixes
could ship without cutting a plugin release. A sensible trade for a two-repo
workflow.

That workflow is still live: the browser half is developed in MakD's repo and
auto-pulled into this one (`.github/pull.yml`). This change leaves that sync
untouched, since it does not modify `slideshowpure.js` or `.css`, only where
they are served from. What changes is when a synced change reaches users: at
the next tagged release instead of within the CDN's cache window.
[#174](https://github.com/IAmParadox27/jellyfin-plugin-media-bar/issues/174)
shows what the instant path costs users when a change misfires: no version, no
way to decline it, no way back. With embedded assets, browser-side changes
ship the way the DLL already ships, through a tagged release and the plugin
repository manifest, picked up by Jellyfin's normal plugin-update task,
versioned and downgradable.

## Testing unreleased assets on a dev server

The decoupling stays available where it is actually wanted. `VersionString`
still accepts any git ref and fetches it from jsDelivr, so a test server can
track work in progress without a plugin build:

- a commit SHA is the most predictable: immutable, so jsDelivr serves it
  immediately and never re-resolves it
- a branch name works too (`dev`, a PR branch), with the caveat that jsDelivr
  caches branch refs for around 12 hours; note `main` and `latest` are the two
  branch names this cannot use, since they now mean "embedded"
- the ref must exist in this repo: the jsDelivr org and repo are fixed, only
  the ref is configurable

## Verification

Built for `10.11.11` and run in a clean Jellyfin `10.11.11` container with File
Transformation installed:

| `VersionString` | injected into `index.html` | saved value after a page load |
| --- | --- | --- |
| `embedded` (default, written on first run) | `../MediaBar/slideshowpure.css` | unchanged |
| `main` | `../MediaBar/…` | unchanged |
| `latest` | `../MediaBar/…` | unchanged (previously rewritten to `main`) |
| *(empty)* | `../MediaBar/…` | unchanged |
| `2.4.12.0` | `cdn.jsdelivr.net/…@2.4.12.0/…` | unchanged |

`/MediaBar/slideshowpure.js` returns 200 `text/javascript` and is byte-identical
to both the repo file and what jsDelivr serves at `@main`; `.css` returns 200
`text/css`; an unknown file returns 404. The route is anonymous, so the plain
`<script src>` needs no token. Build is clean, no new warnings.

## Note for whoever reviews this

The admin config page also normalised `latest` to `main` client side, so it
displayed a value the server had not stored and persisted it on the next save.
Removed, since both values now mean the same thing.




