### PR TITLE
Add opt-in AllowUnpinnedRefs so main/latest can track jsDelivr again

### DIFF
--- a/src/Jellyfin.Plugin.MediaBar/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Configuration/PluginConfiguration.cs
@@ -16,16 +16,23 @@ namespace Jellyfin.Plugin.MediaBar.Configuration
 
         public string VersionString { get; set; } = EmbeddedVersion;
 
-        public static bool UsesEmbeddedAssets(string? version)
+        public bool AllowUnpinnedRefs { get; set; } = false;
+
+        public static bool UsesEmbeddedAssets(string? version, bool allowUnpinnedRefs)
         {
             version = version?.Trim();
 
+            if (string.IsNullOrWhiteSpace(version) ||
+                string.Equals(version, EmbeddedVersion, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
             // main/latest predate the embedded assets; configs that saved them meant
-            // "newest", which is now the embedded copy
-            return string.IsNullOrWhiteSpace(version) ||
-                   string.Equals(version, EmbeddedVersion, StringComparison.OrdinalIgnoreCase) ||
-                   string.Equals(version, "main", StringComparison.OrdinalIgnoreCase) ||
-                   string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase);
+            // "newest", which is the embedded copy unless the admin opts back in
+            return !allowUnpinnedRefs &&
+                   (string.Equals(version, "main", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase));
         }
 
         public bool UseAvatarsFile { get; set; } = true;

--- a/src/Jellyfin.Plugin.MediaBar/Configuration/config.html
+++ b/src/Jellyfin.Plugin.MediaBar/Configuration/config.html
@@ -37,7 +37,18 @@
                         <label class="inputLabel inputLabelUnfocused" for="txtVersionString">Version</label>
                         <label class="inputLabel inputLabel-float inputLabelUnfocused" for="txtVersionString"></label>
                         <input id="txtVersionString" type="text" is="emby-input" class="emby-input" data-id="txtVersionString" />
-                        <div class="fieldDescription">Where the web assets are loaded from. <code>embedded</code> (also <code>main</code>, <code>latest</code>, or blank) serves the copies shipped inside this plugin, which always match the installed version and need no internet access. Set a tag or commit to load that exact version from jsDelivr instead.</div>
+                        <div class="fieldDescription">Where the web assets are loaded from. <code>embedded</code> (or blank) serves the copies shipped inside this plugin, which always match the installed version and need no internet access. Set a tag or commit to load that exact version from jsDelivr instead. <code>main</code> and <code>latest</code> also mean embedded, unless "Allow unpinned refs" below is enabled.</div>
+                    </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label class="emby-checkbox-label">
+                            <input type="checkbox" id="chkAllowUnpinnedRefs" is="emby-checkbox" class="emby-checkbox" data-id="chkAllowUnpinnedRefs" />
+                            <span class="checkboxLabel">Allow unpinned refs</span>
+                            <span class="checkboxOutline">
+                                <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+                                <span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
+                            </span>
+                        </label>
+                        <div class="fieldDescription">If checked, a Version of <code>main</code> or <code>latest</code> loads the newest unreleased code live from jsDelivr instead of the embedded copies. Updates arrive within about 12 hours of a push, unversioned and without a release.</div>
                     </div>
                     <div class="checkboxContainer checkboxContainer-withDescription">
                         <label class="emby-checkbox-label">
@@ -189,6 +200,7 @@
                     const config = {
                         Enabled: document.querySelector("[data-id=enabledSelect]").value,
                         UseAvatarsFile: document.querySelector("[data-id=chkUseAvatarsFile]").checked,
+                        AllowUnpinnedRefs: document.querySelector("[data-id=chkAllowUnpinnedRefs]").checked,
                         AvatarsPlaylist: document.querySelector("[data-id=txtAvatarsPlaylist]").value,
                         VersionString: document.querySelector("[data-id=txtVersionString]").value,
                         WebConfig: {
@@ -228,6 +240,7 @@
                         .then(function (config) {
                             document.querySelector("[data-id=enabledSelect]").value = config.Enabled;
                             document.querySelector("[data-id=chkUseAvatarsFile]").checked = config.UseAvatarsFile;
+                            document.querySelector("[data-id=chkAllowUnpinnedRefs]").checked = config.AllowUnpinnedRefs;
                             document.querySelector("[data-id=txtAvatarsPlaylist]").value = config.AvatarsPlaylist;
                             
                             document.querySelector("[data-id=txtVersionString]").value = config.VersionString;

--- a/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
+++ b/src/Jellyfin.Plugin.MediaBar/Helpers/TransformationPatches.cs
@@ -106,12 +106,19 @@ namespace Jellyfin.Plugin.MediaBar.Helpers
 
         private static string ResolveAssetBaseUrl()
         {
-            string version = MediaBarPlugin.Instance.Configuration.VersionString.Trim();
+            PluginConfiguration config = MediaBarPlugin.Instance.Configuration;
+            string version = config.VersionString.Trim();
 
-            if (PluginConfiguration.UsesEmbeddedAssets(version))
+            if (PluginConfiguration.UsesEmbeddedAssets(version, config.AllowUnpinnedRefs))
             {
                 // Relative to /web/ so it resolves when Jellyfin is hosted under a base path
                 return "../MediaBar";
+            }
+
+            if (string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase))
+            {
+                // "latest" is not a git ref; it has always meant the main branch
+                version = "main";
             }
 
             return $"https://cdn.jsdelivr.net/gh/IAmParadox27/jellyfin-plugin-media-bar@{version}";


### PR DESCRIPTION
## In short

The opt-in you asked for in [#175](https://github.com/IAmParadox27/jellyfin-plugin-media-bar/pull/175#issuecomment-5427304094): a new setting, disabled by default, that lets `main` and `latest` load live from jsDelivr again for people who want to live a little. Everyone else keeps the embedded assets.

## Behaviour

| `VersionString` | option off (default) | option on |
| --- | --- | --- |
| `embedded` / blank | embedded | embedded |
| `main` | embedded | jsDelivr `@main` |
| `latest` | embedded | jsDelivr `@main` (as before, `latest` maps to the main branch) |
| tag or commit | jsDelivr at that ref | jsDelivr at that ref |

The config page gains an "Allow unpinned refs" checkbox whose description says what enabling it means: unreleased code, arriving within about 12 hours of a push, unversioned.

![Allow unpinned refs setting](https://raw.githubusercontent.com/skylerwshaw/jellyfin-plugin-media-bar/assets/allow-unpinned-refs-settings.jpg)

## Verification

Every row of the table above verified in a clean Jellyfin 10.11.11 container, plus that a page load never rewrites the saved config. The screenshot is from that container.
