### PR TITLE
Fix SlideTimer lifecycle

### DIFF
--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -2309,6 +2309,7 @@ const SlideshowManager = {
       }, CONFIG.shuffleInterval);
 
       STATE.slideshow.slideInterval.stop();
+      STATE.slideshow.slideInterval = null; // Ensure that updateCurrentSlide doesn't restart the timer
 
       await this.updateCurrentSlide(0);
 


### PR DESCRIPTION
This merge request sets `slideInterval` to `null` to fix the lifecycle of the first `SlideTimer`.

Upstream pr: https://github.com/MakD/Jellyfin-Media-Bar/pull/115

> [!NOTE]
> This might not be the permanent fix as I'm currently waiting for feedback to this question: https://github.com/MakD/Jellyfin-Media-Bar/pull/115#issuecomment-5402603755

Closes #173