### PR TITLE
Add Jellyfin 12.0 build target

### DIFF
--- a/src/Jellyfin.Plugin.MediaBar/Jellyfin.Plugin.MediaBar.csproj
+++ b/src/Jellyfin.Plugin.MediaBar/Jellyfin.Plugin.MediaBar.csproj
@@ -1,14 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <JellyfinVersion>10.11.2</JellyfinVersion>
+        <JellyfinVersion Condition="'$(JellyfinVersion)' == ''">12.0.0</JellyfinVersion>
         <JellyfinNugetVersion Condition="!$(JellyfinVersion.StartsWith('10.11'))">$(JellyfinVersion)</JellyfinNugetVersion>
         <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('10.11'))">$(JellyfinVersion)</JellyfinNugetVersion>
         <JellyfinNugetVersion Condition="'$(JellyfinVersion)' == '10.11.1'">10.11.0</JellyfinNugetVersion>
         <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('10.11.0'))">10.11.0</JellyfinNugetVersion>
         <JellyfinNugetVersion Condition="'$(JellyfinVersion)' == '10.11.10'">10.11.9</JellyfinNugetVersion>
+        <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('12.'))">12.0.0-rc5</JellyfinNugetVersion>
         <TargetFramework Condition="$(JellyfinVersion.StartsWith('10.11'))">net9.0</TargetFramework>
         <TargetFramework Condition="'$(JellyfinVersion)' == '10.10.7'">net8.0</TargetFramework>
+        <TargetFramework Condition="$(JellyfinVersion.StartsWith('12.'))">net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -61,4 +63,11 @@
         <Exec Condition="$(JellyfinVersion.StartsWith('10.11'))" Command="xcopy $(TargetDir) &quot;C:\ProgramData\Jellyfin\Server_10_11\plugins\MediaBar&quot; /y" />
         <Exec Condition="'$(JellyfinVersion)' == '10.10.7'"     Command="xcopy $(TargetDir) &quot;C:\ProgramData\Jellyfin\Server_10_10_7\plugins\MediaBar&quot; /y" />
     </Target>
+
+    <!-- Remove 12.0 Specific Code from non 12.x builds -->
+    <ItemGroup Condition="!$(JellyfinVersion.StartsWith('12.'))">
+        <None Include="JellyfinVersionSpecific/12.0/*.cs" />
+        <Compile Remove="JellyfinVersionSpecific/12.0/*.cs" />
+    </ItemGroup>
+
 </Project>

--- a/src/Jellyfin.Plugin.MediaBar/JellyfinVersionSpecific/12.0/StartupServiceHelper.cs
+++ b/src/Jellyfin.Plugin.MediaBar/JellyfinVersionSpecific/12.0/StartupServiceHelper.cs
@@ -1,0 +1,15 @@
+﻿using MediaBrowser.Model.Tasks;
+
+namespace Jellyfin.Plugin.MediaBar.JellyfinVersionSpecific
+{
+    public static class StartupServiceHelper
+    {
+        public static IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+        {
+            yield return new TaskTriggerInfo()
+            {
+                Type = TaskTriggerInfoType.StartupTrigger
+            };
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.MediaBar/JellyfinVersionSpecific/12.0/UserHelper.cs
+++ b/src/Jellyfin.Plugin.MediaBar/JellyfinVersionSpecific/12.0/UserHelper.cs
@@ -1,0 +1,9 @@
+﻿using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.MediaBar.JellyfinVersionSpecific
+{
+    public static class UserHelper
+    {
+        public static IEnumerable<Guid> GetAllUserIds(this IUserManager userManager) => userManager.GetUsersIds();
+    }
+}


### PR DESCRIPTION
Adds a Jellyfin 12.0 build target.

Retargets to `net10.0` against the Jellyfin `12.0.0-rc5` NuGet packages. Where the project already
parameterises on `<JellyfinVersion>`, this just teaches that existing machinery about 12.x and
leaves the older targets untouched.

Built and loaded successfully on Jellyfin 12.0-rc5.
